### PR TITLE
FIX:opacity bug fix in gallery & speakers

### DIFF
--- a/src/Components/Speaker/Speakers.jsx
+++ b/src/Components/Speaker/Speakers.jsx
@@ -7,7 +7,7 @@ import { IoIosArrowBack, IoIosArrowForward } from "react-icons/io";
 import Data from "../../Data/Speakers.json";
 
 import style from "./Speakers.module.scss";
-
+import "./Speakers.scss";
 import "swiper/css";
 import "swiper/css/effect-coverflow";
 import "swiper/css/pagination";
@@ -19,7 +19,7 @@ const Speakers = () => {
         <h1>Speakers</h1>
       </div>
 
-      <div className={style.strtcpkrsmain}>
+      <div className={`${style.strtcpkrsmain} speaker`}>
         <Swiper
           effect="coverflow"
           grabCursor

--- a/src/Components/Speaker/Speakers.scss
+++ b/src/Components/Speaker/Speakers.scss
@@ -1,0 +1,7 @@
+.speaker {
+  .swiper-slide-prev,
+  .swiper-slide-next {
+    opacity: 0.4;
+    transition: 1s ease-in-out;
+  }
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -95,9 +95,3 @@
   box-sizing: border-box;
   font-family: var(--srijan4-font-1);
 }
-
-.swiper-slide-prev,
-.swiper-slide-next {
-  opacity: 0.4;
-  transition: 1s ease-in-out;
-}


### PR DESCRIPTION
**BUG:-**

- global css rule was applied on  .swiper-slide-prev and .swiper-slide-next in index.scss due to which it was also affecting gallery section's previous and next slide which was not desired.

**FIX:-**

- A separate speakers.scss file has been created to overcome this issue.
